### PR TITLE
Disable email notifications for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ jdk:
   - oraclejdk8
 notifications:
   slack: gotofail:rNibSSSvoPtDAS7wws1KtdXd
+  email: false
 before_install:
   - "[ \"$BUILD_PR_BRANCH\" = \"true\" ] && git checkout -b dummyBranch && git checkout master && git merge dummyBranch; true"
 env:


### PR DESCRIPTION
We already have notifications in slack for Travis, there is no need to receive duplicate messages. Also, we are not able to merge branches with failing builds. We will know when a build has failed.
