### PR TITLE
Grid and pane scaling and clipping

### DIFF
--- a/src/main/java/gui/RootCenterArea.java
+++ b/src/main/java/gui/RootCenterArea.java
@@ -24,9 +24,9 @@ public class RootCenterArea extends ScrollPane {
     @Getter @Setter
     private int timelineWidth = 200;
     @Getter @Setter
-    private int numberOfTimelines = 5;
+    private int numberOfTimelines = 8;
     @Getter @Setter
-    private int numberOfCounts = 10;
+    private int numberOfCounts = 20;
 
     @Getter
     private RootPane rootPane;
@@ -47,14 +47,19 @@ public class RootCenterArea extends ScrollPane {
      */
     RootCenterArea(RootPane rootPane) {
         this.rootPane = rootPane;
-        parentPane = new AnchorPane();
-        grid = new TimelinesGridPane(5, 20, 1000, 1000);
-        parentPane.getChildren().add(grid);
+        //setFitToWidth(true);
 
-        parentPane.setMaxWidth(1000);
-        parentPane.setMinWidth(1000);
+        parentPane = new AnchorPane();
+        grid = new TimelinesGridPane(numberOfTimelines, numberOfCounts, 1000, 1000);
+
+        parentPane.setLeftAnchor(grid, 0.0);
+        parentPane.setRightAnchor(grid, 0.0);
+
+        parentPane.getChildren().add(grid);
         parentPane.setMinHeight(1000);
         parentPane.setMinWidth(1000);
+
+        setFitToWidth(true);
         setContent(parentPane);
     }
 

--- a/src/main/java/gui/RootCenterArea.java
+++ b/src/main/java/gui/RootCenterArea.java
@@ -1,15 +1,9 @@
 package gui;
 
-import javafx.geometry.Bounds;
-import javafx.geometry.Insets;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.AnchorPane;
-import javafx.scene.layout.ColumnConstraints;
-import javafx.scene.layout.GridPane;
-import javafx.scene.layout.RowConstraints;
 import lombok.Getter;
 import lombok.Setter;
-import java.util.ArrayList;
 
 /**
  * Class representing the center (main section) of the gui.
@@ -47,19 +41,21 @@ public class RootCenterArea extends ScrollPane {
      */
     RootCenterArea(RootPane rootPane) {
         this.rootPane = rootPane;
-        //setFitToWidth(true);
 
         parentPane = new AnchorPane();
         grid = new TimelinesGridPane(numberOfTimelines, numberOfCounts, 1000, 1000);
 
         parentPane.setLeftAnchor(grid, 0.0);
         parentPane.setRightAnchor(grid, 0.0);
+       // parentPane.setBottomAnchor(grid, 0.0);
+        parentPane.setTopAnchor(grid, 0.0);
 
         parentPane.getChildren().add(grid);
         parentPane.setMinHeight(1000);
         parentPane.setMinWidth(1000);
 
         setFitToWidth(true);
+        //setFitToHeight(true);
         setContent(parentPane);
     }
 

--- a/src/main/java/gui/SnappingPane.java
+++ b/src/main/java/gui/SnappingPane.java
@@ -28,8 +28,9 @@ public class SnappingPane extends Pane {
     public SnappingPane(int row, int column, double width, double height) {
         this.row = row;
         this.column = column;
-        this.setWidth(width);
-        this.setHeight(height);
+        // don't enforce width, let grid handle this - Mark
+        //this.setWidth(width);
+        //this.setHeight(height);
         this.bottomHalf = false;
     }
 }

--- a/src/main/java/gui/SnappingPane.java
+++ b/src/main/java/gui/SnappingPane.java
@@ -28,9 +28,6 @@ public class SnappingPane extends Pane {
     public SnappingPane(int row, int column, double width, double height) {
         this.row = row;
         this.column = column;
-        // don't enforce width, let grid handle this - Mark
-        //this.setWidth(width);
-        //this.setHeight(height);
         this.bottomHalf = false;
     }
 }

--- a/src/main/java/gui/TimelinesGridPane.java
+++ b/src/main/java/gui/TimelinesGridPane.java
@@ -4,6 +4,7 @@ import javafx.geometry.Bounds;
 import javafx.geometry.Insets;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.RowConstraints;
 import lombok.Getter;
 
@@ -41,24 +42,27 @@ public class TimelinesGridPane extends GridPane {
                              double width, double height) {
         this.numberOfTimelines = numberOfTimelines;
         this.numberOfCounts = numberOfCounts;
-        this.setWidth(width);
-        this.setMinHeight(height);
+       // this.setWidth(width);
         this.panes = new ArrayList<>();
-
-        this.setMaxWidth(width);
-        this.setMinWidth(width);
-        this.setMaxHeight(height);
-        this.setMinHeight(height);
+        setMaxWidth(Double.MAX_VALUE);
+        //this.setMaxWidth(width);
+       // this.setMinWidth(width);
+       // this.setMaxHeight(height);
+       // this.setMinHeight(height);
 
         addPanes();
 
         this.setGridLinesVisible(true);
-//        this.setHgap(50);
-        this.setPadding(new Insets(25, 25, 25, 25));
+//        this.setHgap(50); // uncomment to add gaps between timeliens.
+       // this.setPadding(new Insets(25, 25, 25, 25));
 
         // set constraints
         for (int i = 0; i < numberOfTimelines; i++) {
-            this.getColumnConstraints().add(new ColumnConstraints(timelineWidth));
+            ColumnConstraints columConstraint = new ColumnConstraints();
+            columConstraint.setMinWidth(100.0);
+            columConstraint.setPercentWidth(100.0 / numberOfTimelines);
+            columConstraint.setHgrow(Priority.ALWAYS);
+            this.getColumnConstraints().add(columConstraint);
         }
         for (int i = 0; i < numberOfCounts; i++) {
             this.getRowConstraints().add(new RowConstraints(countHeight));

--- a/src/main/java/gui/TimelinesGridPane.java
+++ b/src/main/java/gui/TimelinesGridPane.java
@@ -1,5 +1,6 @@
 package gui;
 
+import java.util.ArrayList;
 import javafx.geometry.Bounds;
 import javafx.geometry.Insets;
 import javafx.scene.layout.ColumnConstraints;
@@ -8,7 +9,6 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.RowConstraints;
 import lombok.Getter;
 
-import java.util.ArrayList;
 
 /**
  * Created by Bart.
@@ -50,7 +50,6 @@ public class TimelinesGridPane extends GridPane {
         addPanes();
 
         this.setGridLinesVisible(true);
-        //this.setHgap(50); // uncomment to add gaps between timelines.
         this.setPadding(new Insets(5, 5, 5, 5));
 
         // set constraints, with minimum size 100x100, and maximum size infinite.

--- a/src/main/java/gui/TimelinesGridPane.java
+++ b/src/main/java/gui/TimelinesGridPane.java
@@ -42,30 +42,31 @@ public class TimelinesGridPane extends GridPane {
                              double width, double height) {
         this.numberOfTimelines = numberOfTimelines;
         this.numberOfCounts = numberOfCounts;
-       // this.setWidth(width);
         this.panes = new ArrayList<>();
-        setMaxWidth(Double.MAX_VALUE);
-        //this.setMaxWidth(width);
-       // this.setMinWidth(width);
-       // this.setMaxHeight(height);
-       // this.setMinHeight(height);
+        this.setMinWidth(width);
+        this.setMinHeight(height);
+        this.setMaxHeight(height);
 
         addPanes();
 
         this.setGridLinesVisible(true);
-//        this.setHgap(50); // uncomment to add gaps between timeliens.
-       // this.setPadding(new Insets(25, 25, 25, 25));
+        //this.setHgap(50); // uncomment to add gaps between timelines.
+        this.setPadding(new Insets(5, 5, 5, 5));
 
-        // set constraints
+        // set constraints, with minimum size 100x100, and maximum size infinite.
         for (int i = 0; i < numberOfTimelines; i++) {
-            ColumnConstraints columConstraint = new ColumnConstraints();
-            columConstraint.setMinWidth(100.0);
-            columConstraint.setPercentWidth(100.0 / numberOfTimelines);
-            columConstraint.setHgrow(Priority.ALWAYS);
-            this.getColumnConstraints().add(columConstraint);
+            ColumnConstraints rc = new ColumnConstraints();
+            rc.setMinWidth(100.0);
+            rc.setPercentWidth(100.0 / numberOfTimelines);
+            rc.setHgrow(Priority.ALWAYS);
+            this.getColumnConstraints().add(rc);
         }
         for (int i = 0; i < numberOfCounts; i++) {
-            this.getRowConstraints().add(new RowConstraints(countHeight));
+            RowConstraints rc = new RowConstraints();
+            rc.setMinHeight(100.0);
+            rc.setPercentHeight(100.0 / numberOfCounts);
+            rc.setVgrow(Priority.ALWAYS);
+            this.getRowConstraints().add(rc);
         }
     }
 

--- a/src/main/java/gui/TimetableBlock.java
+++ b/src/main/java/gui/TimetableBlock.java
@@ -1,17 +1,16 @@
 package gui;
 
 import javafx.event.EventHandler;
-import javafx.geometry.BoundingBox;
-import javafx.geometry.Bounds;
-import javafx.geometry.Point2D;
+import javafx.geometry.*;
 import javafx.scene.Node;
 import javafx.scene.Parent;
+import javafx.scene.control.Label;
 import javafx.scene.input.MouseEvent;
-import javafx.scene.layout.AnchorPane;
-import javafx.scene.layout.GridPane;
-import javafx.scene.layout.Pane;
-import javafx.scene.layout.Region;
+import javafx.scene.layout.*;
+import javafx.scene.shape.Rectangle;
+import javafx.scene.text.Text;
 import lombok.Getter;
+import org.w3c.dom.css.Rect;
 
 /**
  * Class that resembles a draggable, resiable block inside the timetable.
@@ -21,16 +20,27 @@ public class TimetableBlock extends Region {
 
     public enum DraggingTypes { Move, Resize_Top, Resize_Right, Resize_Bottom, Resize_Left }
 
+    /*
+        Styling variables.
+        For styling and displayable content.
+     */
+
+    private String normalStyle;
+    private String dragStyle;
+
+    private String title = "dummyTitle with some extension";
+
+    /*
+        Misc variables.
+        For dragging, interaction, etc.
+     */
+
     private TimetableBlock thisBlock;
     private Pane dummyPane;
     private Pane feedbackPane;
 
     private double dragXOffset;
     private double dragYOffset;
-
-    private String normalStyle;
-    private String dragStyle;
-
 
     private RootCenterArea pane;
     private boolean dragging;
@@ -85,6 +95,37 @@ public class TimetableBlock extends Region {
 
         this.pane = pane;
         setStyle(normalStyle);
+
+        VBox contentPane = new VBox();
+        contentPane.setMaxHeight(100.0);
+        Rectangle clipRegion = new Rectangle();
+        clipRegion.widthProperty().bind(widthProperty());
+        clipRegion.heightProperty().bind(heightProperty());
+        contentPane.setClip(clipRegion);
+        getChildren().add(contentPane);
+
+        Label label1 = new Label(title);
+        label1.setMaxWidth(pane.getGrid().getTimelineWidth());
+        label1.setPadding(new Insets(5,5,5,5));
+        Label label2 = new Label(title);
+        label2.setMaxWidth(pane.getGrid().getTimelineWidth());
+        label2.setPadding(new Insets(5,5,5,5));
+        Label label3 = new Label(title);
+        label3.setMaxWidth(pane.getGrid().getTimelineWidth());
+        label3.setPadding(new Insets(5,5,5,5));
+        Label label4 = new Label(title);
+        label4.setMaxWidth(pane.getGrid().getTimelineWidth());
+        label4.setPadding(new Insets(5,5,5,5));
+        Label label5 = new Label(title);
+        label5.setMaxWidth(pane.getGrid().getTimelineWidth());
+        label5.setPadding(new Insets(5,5,5,5));
+
+        contentPane.getChildren().add(label1);
+        contentPane.getChildren().add(label2);
+        contentPane.getChildren().add(label3);
+        contentPane.getChildren().add(label4);
+        contentPane.getChildren().add(label5);
+
         this.margin = 15;
 
         // mouse event handlers

--- a/src/main/java/gui/TimetableBlock.java
+++ b/src/main/java/gui/TimetableBlock.java
@@ -96,19 +96,18 @@ public class TimetableBlock extends Region {
         this.pane = pane;
         setStyle(normalStyle);
 
-        VBox contentPane = new VBox();
-        VBox dummyContentPane = new VBox();
-
-        Rectangle clipRegion = new Rectangle();
+        VBox contentPane = new VBox(); // content pane for our block.
+        Rectangle clipRegion = new Rectangle(); // clip region to restrict content from exiting content pane.
         clipRegion.widthProperty().bind(widthProperty());
-        clipRegion.heightProperty().bind(heightProperty().subtract(10.0));
-        Rectangle dummyClipRegion = new Rectangle();
-        dummyClipRegion.widthProperty().bind(widthProperty());
-        dummyClipRegion.heightProperty().bind(heightProperty().subtract(10.0));
-
+        clipRegion.heightProperty().bind(heightProperty());
         contentPane.setClip(clipRegion);
-        dummyContentPane.setClip(dummyClipRegion);
         getChildren().add(contentPane);
+
+        VBox dummyContentPane = new VBox(); // content pane for dummy block
+        Rectangle dummyClipRegion = new Rectangle();// clip region to restrict content from exiting dummy pane.
+        dummyClipRegion.widthProperty().bind(dummyPane.widthProperty());
+        dummyClipRegion.heightProperty().bind(dummyPane.heightProperty());
+        dummyContentPane.setClip(dummyClipRegion);
         dummyPane.getChildren().add(dummyContentPane);
 
         Label label1 = new Label(title);

--- a/src/main/java/gui/TimetableBlock.java
+++ b/src/main/java/gui/TimetableBlock.java
@@ -97,12 +97,19 @@ public class TimetableBlock extends Region {
         setStyle(normalStyle);
 
         VBox contentPane = new VBox();
-        contentPane.setMaxHeight(100.0);
+        VBox dummyContentPane = new VBox();
+
         Rectangle clipRegion = new Rectangle();
         clipRegion.widthProperty().bind(widthProperty());
-        clipRegion.heightProperty().bind(heightProperty());
+        clipRegion.heightProperty().bind(heightProperty().subtract(10.0));
+        Rectangle dummyClipRegion = new Rectangle();
+        dummyClipRegion.widthProperty().bind(widthProperty());
+        dummyClipRegion.heightProperty().bind(heightProperty().subtract(10.0));
+
         contentPane.setClip(clipRegion);
+        dummyContentPane.setClip(dummyClipRegion);
         getChildren().add(contentPane);
+        dummyPane.getChildren().add(dummyContentPane);
 
         Label label1 = new Label(title);
         label1.setMaxWidth(pane.getGrid().getTimelineWidth());
@@ -116,15 +123,29 @@ public class TimetableBlock extends Region {
         Label label4 = new Label(title);
         label4.setMaxWidth(pane.getGrid().getTimelineWidth());
         label4.setPadding(new Insets(5,5,5,5));
+
         Label label5 = new Label(title);
         label5.setMaxWidth(pane.getGrid().getTimelineWidth());
         label5.setPadding(new Insets(5,5,5,5));
+        Label label6 = new Label(title);
+        label6.setMaxWidth(pane.getGrid().getTimelineWidth());
+        label6.setPadding(new Insets(5,5,5,5));
+        Label label7 = new Label(title);
+        label7.setMaxWidth(pane.getGrid().getTimelineWidth());
+        label7.setPadding(new Insets(5,5,5,5));
+        Label label8 = new Label(title);
+        label8.setMaxWidth(pane.getGrid().getTimelineWidth());
+        label8.setPadding(new Insets(5,5,5,5));
 
         contentPane.getChildren().add(label1);
         contentPane.getChildren().add(label2);
         contentPane.getChildren().add(label3);
         contentPane.getChildren().add(label4);
-        contentPane.getChildren().add(label5);
+
+        dummyContentPane.getChildren().add(label5);
+        dummyContentPane.getChildren().add(label6);
+        dummyContentPane.getChildren().add(label7);
+        dummyContentPane.getChildren().add(label8);
 
         this.margin = 15;
 

--- a/src/main/java/gui/TimetableBlock.java
+++ b/src/main/java/gui/TimetableBlock.java
@@ -1,24 +1,25 @@
 package gui;
 
-import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
 import javafx.event.EventHandler;
-import javafx.geometry.*;
-import javafx.scene.Node;
+import javafx.geometry.Bounds;
+import javafx.geometry.Insets;
+import javafx.geometry.Point2D;
 import javafx.scene.Parent;
 import javafx.scene.control.Label;
 import javafx.scene.input.MouseEvent;
-import javafx.scene.layout.*;
+import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
 import javafx.scene.shape.Rectangle;
-import javafx.scene.text.Text;
 import lombok.Getter;
-import org.w3c.dom.css.Rect;
 
 /**
  * Class that resembles a draggable, resiable block inside the timetable.
  * Highly volatile. Do not poke too much.
  */
-public class TimetableBlock extends Region {
+public class TimetableBlock extends Pane {
 
     public enum DraggingTypes { Move, Resize_Top, Resize_Right, Resize_Bottom, Resize_Left }
 
@@ -27,8 +28,14 @@ public class TimetableBlock extends Region {
         For styling and displayable content.
      */
 
-    private String normalStyle;
-    private String dragStyle;
+    private String normalStyle = "-fx-border-style: solid inside;"
+            + "-fx-border-width: 3;"
+            + "-fx-border-color: yellow;"
+            + "-fx-background-color: orange;";
+    private String dragStyle = "-fx-border-style: solid inside;"
+            + "-fx-border-width: 3;"
+            + "-fx-border-color: red;"
+            + "-fx-background-color: orange;";
 
     private String title = "dummyTitle with some extension";
 
@@ -40,6 +47,9 @@ public class TimetableBlock extends Region {
     private TimetableBlock thisBlock;
     private Pane dummyPane;
     private Pane feedbackPane;
+
+    private VBox contentPane;
+    private VBox dummyContentPane;
 
     private double dragXOffset;
     private double dragYOffset;
@@ -72,59 +82,28 @@ public class TimetableBlock extends Region {
         this.parentBlock = parent;
 
         feedbackPane = new Pane();
-        //feedbackPane.setPrefHeight(100);
-        //feedbackPane.setPrefWidth(200);
         feedbackPane.setStyle("-fx-background-color: red");
         feedbackPane.setVisible(false);
 
         dummyPane = new Pane();
-        dummyPane.setPrefHeight(100);
-        dummyPane.setPrefWidth(200);
         dummyPane.setStyle("-fx-background-color: green");
         dummyPane.setVisible(false);
 
         pane.getParentPane().getChildren().add(dummyPane);
         pane.getGrid().add(feedbackPane, 0, 0);
 
-        this.normalStyle = "-fx-border-style: solid inside;"
-                + "-fx-border-width: 3;"
-                + "-fx-border-color: yellow;"
-                + "-fx-background-color: orange;";
-        this.dragStyle = "-fx-border-style: solid inside;"
-                + "-fx-border-width: 3;"
-                + "-fx-border-color: red;"
-                + "-fx-background-color: orange;";
-
         this.pane = pane;
         setStyle(normalStyle);
 
-        VBox contentPane = new VBox(); // content pane for our block.
-        Rectangle clipRegion = new Rectangle(); // clip region to restrict content from exiting content pane.
-        clipRegion.widthProperty().bind(widthProperty());
-        clipRegion.heightProperty().bind(heightProperty());
-        contentPane.setClip(clipRegion);
-        getChildren().add(contentPane);
-
-        VBox dummyContentPane = new VBox(); // content pane for dummy block
-        Rectangle dummyClipRegion = new Rectangle();// clip region to restrict content from exiting dummy pane.
-        dummyClipRegion.widthProperty().bind(dummyPane.widthProperty());
-        dummyClipRegion.heightProperty().bind(dummyPane.heightProperty());
-        dummyContentPane.setClip(dummyClipRegion);
-        dummyPane.getChildren().add(dummyContentPane);
+        // content pane for our pane, and our dummy pane
+        contentPane = new VBox();
+        addClipRegion(contentPane, this);
+        dummyContentPane = new VBox();
+        addClipRegion(dummyContentPane, dummyPane);
 
         // test labels, please ignore.
-        for (int i = 0; i < 6; i++) {
-            Label label = new Label(title);
-            label.setPrefWidth(pane.getGrid().getTimelineWidth());
-            label.setPadding(new Insets(5,5,5,5));
-            contentPane.getChildren().add(label);
-        }
-        for (int i = 0; i < 6; i++) {
-            Label label = new Label(title);
-            label.setPrefWidth(pane.getGrid().getTimelineWidth());
-            label.setPadding(new Insets(5,5,5,5));
-            dummyContentPane.getChildren().add(label);
-        }
+        addTestLabels(contentPane);
+        addTestLabels((dummyContentPane));
 
         this.margin = 15;
 
@@ -132,6 +111,32 @@ public class TimetableBlock extends Region {
         setOnMousePressed(getOnPressedHandler());
         setOnMouseDragged(getOnDraggedHandler());
         setOnMouseReleased(getOnreleaseHandler());
+    }
+
+    /**
+     * Add clip region to pane (pane0 and its content (vbox).
+     * @param vbox the VBox in which content is located.
+     * @param pane the Pane in which the vbox is located.
+     */
+    private void addClipRegion(VBox vbox, Pane pane) {
+        Rectangle clipRegion = new Rectangle(); // clip region to restrict content
+        clipRegion.widthProperty().bind(pane.widthProperty());
+        clipRegion.heightProperty().bind(pane.heightProperty());
+        vbox.setClip(clipRegion);
+        pane.getChildren().add(vbox);
+    }
+
+    /**
+     * Temporary helper function to add test labels to panes.
+     * @param vbox pane to add to
+     */
+    private void addTestLabels(VBox vbox) {
+        for (int i = 0; i < 6; i++) {
+            Label label = new Label(title);
+            label.setPrefWidth(pane.getGrid().getTimelineWidth());
+            label.setPadding(new Insets(5,5,5,5));
+            vbox.getChildren().add(label);
+        }
     }
 
     /**

--- a/src/main/java/gui/TimetableBlock.java
+++ b/src/main/java/gui/TimetableBlock.java
@@ -1,5 +1,7 @@
 package gui;
 
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import javafx.event.EventHandler;
 import javafx.geometry.*;
 import javafx.scene.Node;
@@ -70,8 +72,8 @@ public class TimetableBlock extends Region {
         this.parentBlock = parent;
 
         feedbackPane = new Pane();
-        feedbackPane.setPrefHeight(100);
-        feedbackPane.setPrefWidth(200);
+        //feedbackPane.setPrefHeight(100);
+        //feedbackPane.setPrefWidth(200);
         feedbackPane.setStyle("-fx-background-color: red");
         feedbackPane.setVisible(false);
 
@@ -110,41 +112,19 @@ public class TimetableBlock extends Region {
         dummyContentPane.setClip(dummyClipRegion);
         dummyPane.getChildren().add(dummyContentPane);
 
-        Label label1 = new Label(title);
-        label1.setMaxWidth(pane.getGrid().getTimelineWidth());
-        label1.setPadding(new Insets(5,5,5,5));
-        Label label2 = new Label(title);
-        label2.setMaxWidth(pane.getGrid().getTimelineWidth());
-        label2.setPadding(new Insets(5,5,5,5));
-        Label label3 = new Label(title);
-        label3.setMaxWidth(pane.getGrid().getTimelineWidth());
-        label3.setPadding(new Insets(5,5,5,5));
-        Label label4 = new Label(title);
-        label4.setMaxWidth(pane.getGrid().getTimelineWidth());
-        label4.setPadding(new Insets(5,5,5,5));
-
-        Label label5 = new Label(title);
-        label5.setMaxWidth(pane.getGrid().getTimelineWidth());
-        label5.setPadding(new Insets(5,5,5,5));
-        Label label6 = new Label(title);
-        label6.setMaxWidth(pane.getGrid().getTimelineWidth());
-        label6.setPadding(new Insets(5,5,5,5));
-        Label label7 = new Label(title);
-        label7.setMaxWidth(pane.getGrid().getTimelineWidth());
-        label7.setPadding(new Insets(5,5,5,5));
-        Label label8 = new Label(title);
-        label8.setMaxWidth(pane.getGrid().getTimelineWidth());
-        label8.setPadding(new Insets(5,5,5,5));
-
-        contentPane.getChildren().add(label1);
-        contentPane.getChildren().add(label2);
-        contentPane.getChildren().add(label3);
-        contentPane.getChildren().add(label4);
-
-        dummyContentPane.getChildren().add(label5);
-        dummyContentPane.getChildren().add(label6);
-        dummyContentPane.getChildren().add(label7);
-        dummyContentPane.getChildren().add(label8);
+        // test labels, please ignore.
+        for (int i = 0; i < 6; i++) {
+            Label label = new Label(title);
+            label.setPrefWidth(pane.getGrid().getTimelineWidth());
+            label.setPadding(new Insets(5,5,5,5));
+            contentPane.getChildren().add(label);
+        }
+        for (int i = 0; i < 6; i++) {
+            Label label = new Label(title);
+            label.setPrefWidth(pane.getGrid().getTimelineWidth());
+            label.setPadding(new Insets(5,5,5,5));
+            dummyContentPane.getChildren().add(label);
+        }
 
         this.margin = 15;
 


### PR DESCRIPTION
Grid now fills entire screen when resized, up to minimum size after which scroll pane kicks in. Blocks in grid happily follow suit. Displayable content can now (very basically) be added to blocks, and said content will be clipped off at the edges of blocks when it grows too large, for now.
