### PR TITLE
Double counts

### DIFF
--- a/src/main/java/control/CountUtilities.java
+++ b/src/main/java/control/CountUtilities.java
@@ -5,7 +5,7 @@ package control;
  */
 public class CountUtilities {
 
-    public static int numberOfCellsPerCount = 4;
+    public static final int numberOfCellsPerCount = 4;
 
     /**
      * Format double into a nice displayable string.
@@ -20,6 +20,11 @@ public class CountUtilities {
         }
     }
 
+    /**
+     * Parse a string containing a count number to a correctly parsed and formatted string.
+     * @param countNumber - the string containing the countNumber to parse
+     * @return - the parsed and formatted countnumber
+     */
     public static String parseCountNumber(String countNumber) {
         double res = countNumber.isEmpty() ? 0 : Double.parseDouble(countNumber);
         res = Math.round(res * numberOfCellsPerCount)

--- a/src/main/java/control/CountUtilities.java
+++ b/src/main/java/control/CountUtilities.java
@@ -5,7 +5,7 @@ package control;
  */
 public class CountUtilities {
 
-    public static final int numberOfCellsPerCount = 4;
+    public static final int NUMBER_OF_CELLS_PER_COUNT = 4;
 
     /**
      * Format double into a nice displayable string.
@@ -27,8 +27,8 @@ public class CountUtilities {
      */
     public static String parseCountNumber(String countNumber) {
         double res = countNumber.isEmpty() ? 0 : Double.parseDouble(countNumber);
-        res = Math.round(res * numberOfCellsPerCount)
-                / (double) numberOfCellsPerCount;
+        res = Math.round(res * NUMBER_OF_CELLS_PER_COUNT)
+                / (double) NUMBER_OF_CELLS_PER_COUNT;
         return formatDouble(res);
     }
 

--- a/src/main/java/control/CountUtilities.java
+++ b/src/main/java/control/CountUtilities.java
@@ -1,0 +1,32 @@
+package control;
+
+/**
+ * Created by Bart on 10/05/2016.
+ */
+public class CountUtilities {
+
+    public static int numberOfCellsPerCount = 4;
+
+    /**
+     * Format double into a nice displayable string.
+     * @param d - the double to format
+     * @return - a formatted string containng the double
+     */
+    public static String formatDouble(double d) {
+        if (d == (long) d) {
+            return String.format("%d", (long) d);
+        } else {
+            return String.format("%s", d);
+        }
+    }
+
+    public static String parseCountNumber(String countNumber) {
+        double res = countNumber.isEmpty() ? 0 : Double.parseDouble(countNumber);
+        res = Math.round(res * numberOfCellsPerCount)
+                / (double) numberOfCellsPerCount;
+        return formatDouble(res);
+    }
+
+
+}
+

--- a/src/main/java/control/DetailViewController.java
+++ b/src/main/java/control/DetailViewController.java
@@ -72,7 +72,6 @@ public class DetailViewController {
             double newVal = newValue.isEmpty() ? 0 : Double.parseDouble(newValue);
             newVal = Math.round(newVal*4)/4f;
             detailView.getBeginCountField().setText(formatDouble(newVal));
-            System.out.println(formatDouble(newVal));
 
             manager.getActiveShotBlock().setBeginCount(newVal);
             if (manager.getActiveShotBlock() instanceof CameraShotBlock) {
@@ -88,19 +87,34 @@ public class DetailViewController {
     private void initEndCount() {
         detailView.setEndCount(0);
 
-        detailView.getEndCountField().textProperty().addListener(
-                (observable, oldValue, newValue) -> {
-                if (manager.getActiveShotBlock() != null) {
-                    int newVal = !newValue.isEmpty() ? Integer.parseInt(newValue) : 0;
-                    ShotBlock block = manager.getActiveShotBlock();
+        detailView.getEndCountField().focusedProperty().addListener((observable, oldValue, newValue) -> {
+            // exiting focus
+            if (!newValue) {
+                beginCountUpdateHelper();
+            }
+        });
 
-                    block.setEndCount(newVal);
-                    if (manager.getActiveShotBlock() instanceof CameraShotBlock) {
-                        ((CameraShotBlock) manager.getActiveShotBlock())
-                                .getShot().setEndCount(newVal);
-                    }
-                }
-            });
+        detailView.getEndCountField().setOnKeyPressed(event -> {
+            if (event.getCode().equals(KeyCode.ENTER)) {
+                beginCountUpdateHelper();
+            }
+        });
+    }
+
+    private void endCountUpdateHelper() {
+        if (manager.getActiveShotBlock() != null) {
+
+            String newValue = detailView.getEndCountField().getText();
+            double newVal = newValue.isEmpty() ? 0 : Double.parseDouble(newValue);
+            newVal = Math.round(newVal*4)/4f;
+            detailView.getEndCountField().setText(formatDouble(newVal));
+
+            manager.getActiveShotBlock().setEndCount(newVal);
+            if (manager.getActiveShotBlock() instanceof CameraShotBlock) {
+                ((CameraShotBlock) manager.getActiveShotBlock()).getShot()
+                        .setEndCount(newVal);
+            }
+        }
     }
 
     /**

--- a/src/main/java/control/DetailViewController.java
+++ b/src/main/java/control/DetailViewController.java
@@ -14,8 +14,6 @@ public class DetailViewController {
     private ControllerManager manager;
     private ScriptingProject project;
 
-    private final int numberOfCellsPerCount = 4;
-
     /**
      * Constructor.
      * @param manager - the controller manager this controller belongs to
@@ -52,30 +50,14 @@ public class DetailViewController {
     }
 
     /**
-     * Format double into a nice displayable string.
-     * @param d - the double to format
-     * @return - a formatted string containng the double
-     */
-    private String formatDouble(double d) {
-        if (d == (long) d) {
-            return String.format("%d", (long) d);
-        } else {
-            return String.format("%s", d);
-        }
-    }
-
-    /**
      * Helper for when the begincount field is edited.
      * Parses entry to quarters and updates all the values
      */
     private void beginCountUpdateHelper() {
         if (manager.getActiveShotBlock() != null) {
-
-            String newValue = detailView.getBeginCountField().getText();
-            double newVal = newValue.isEmpty() ? 0 : Double.parseDouble(newValue);
-            newVal = Math.round(newVal * numberOfCellsPerCount)
-                    / (double) numberOfCellsPerCount;
-            detailView.getBeginCountField().setText(formatDouble(newVal));
+            String newValue = CountUtilities.parseCountNumber(detailView.getBeginCountField().getText());
+            detailView.getBeginCountField().setText(newValue);
+            double newVal = Double.parseDouble(newValue);
 
             manager.getActiveShotBlock().setBeginCount(newVal);
             if (manager.getActiveShotBlock() instanceof CameraShotBlock) {
@@ -113,11 +95,10 @@ public class DetailViewController {
     private void endCountUpdateHelper() {
         if (manager.getActiveShotBlock() != null) {
 
-            String newValue = detailView.getEndCountField().getText();
-            double newVal = newValue.isEmpty() ? 0 : Double.parseDouble(newValue);
-            newVal = Math.round(newVal * numberOfCellsPerCount)
-                    / (double) numberOfCellsPerCount;
-            detailView.getEndCountField().setText(formatDouble(newVal));
+            String newValue = CountUtilities.parseCountNumber(detailView.getBeginCountField().getText());
+            detailView.getBeginCountField().setText(newValue);
+            double newVal = Double.parseDouble(newValue);
+            detailView.getEndCountField().setText(newValue);
 
             manager.getActiveShotBlock().setEndCount(newVal);
             if (manager.getActiveShotBlock() instanceof CameraShotBlock) {
@@ -171,7 +152,6 @@ public class DetailViewController {
             detailView.setDescription(manager.getActiveShotBlock().getDescription());
             detailView.setName(manager.getActiveShotBlock().getName());
 
-            // TODO: Make doubles possible in detailview
             detailView.setBeginCount(manager.getActiveShotBlock().getBeginCount());
             detailView.setEndCount(manager.getActiveShotBlock().getEndCount());
         } else {

--- a/src/main/java/control/DetailViewController.java
+++ b/src/main/java/control/DetailViewController.java
@@ -162,8 +162,8 @@ public class DetailViewController {
             detailView.setName(manager.getActiveShotBlock().getName());
 
             // TODO: Make doubles possible in detailview
-            detailView.setBeginCount((int) manager.getActiveShotBlock().getBeginCount());
-            detailView.setEndCount((int) manager.getActiveShotBlock().getEndCount());
+            detailView.setBeginCount(manager.getActiveShotBlock().getBeginCount());
+            detailView.setEndCount(manager.getActiveShotBlock().getEndCount());
         } else {
             detailView.resetDetails();
         }

--- a/src/main/java/control/DetailViewController.java
+++ b/src/main/java/control/DetailViewController.java
@@ -95,7 +95,7 @@ public class DetailViewController {
     private void endCountUpdateHelper() {
         if (manager.getActiveShotBlock() != null) {
 
-            String newValue = CountUtilities.parseCountNumber(detailView.getBeginCountField().getText());
+            String newValue = CountUtilities.parseCountNumber(detailView.getEndCountField().getText());
             detailView.getBeginCountField().setText(newValue);
             double newVal = Double.parseDouble(newValue);
             detailView.getEndCountField().setText(newValue);

--- a/src/main/java/control/DetailViewController.java
+++ b/src/main/java/control/DetailViewController.java
@@ -55,7 +55,8 @@ public class DetailViewController {
      */
     private void beginCountUpdateHelper() {
         if (manager.getActiveShotBlock() != null) {
-            String newValue = CountUtilities.parseCountNumber(detailView.getBeginCountField().getText());
+            String newValue = CountUtilities.parseCountNumber(
+                    detailView.getBeginCountField().getText());
             detailView.getBeginCountField().setText(newValue);
             double newVal = Double.parseDouble(newValue);
 
@@ -95,7 +96,8 @@ public class DetailViewController {
     private void endCountUpdateHelper() {
         if (manager.getActiveShotBlock() != null) {
 
-            String newValue = CountUtilities.parseCountNumber(detailView.getEndCountField().getText());
+            String newValue = CountUtilities.parseCountNumber(
+                    detailView.getEndCountField().getText());
             detailView.getBeginCountField().setText(newValue);
             double newVal = Double.parseDouble(newValue);
             detailView.getEndCountField().setText(newValue);

--- a/src/main/java/control/DetailViewController.java
+++ b/src/main/java/control/DetailViewController.java
@@ -1,18 +1,9 @@
 package control;
 
-import data.CameraShot;
 import data.ScriptingProject;
 import gui.centerarea.CameraShotBlock;
 import gui.headerarea.DetailView;
-import gui.centerarea.ShotBlock;
-import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
-import javafx.event.EventHandler;
-import javafx.scene.input.DataFormat;
 import javafx.scene.input.KeyCode;
-import javafx.scene.input.KeyEvent;
-
-import java.text.DecimalFormat;
 
 /**
  * Created by Bart.
@@ -22,6 +13,8 @@ public class DetailViewController {
     private DetailView detailView;
     private ControllerManager manager;
     private ScriptingProject project;
+
+    private final int numberOfCellsPerCount = 4;
 
     /**
      * Constructor.
@@ -43,20 +36,26 @@ public class DetailViewController {
     private void initBeginCount() {
         detailView.setBeginCount(0);
 
-        detailView.getBeginCountField().focusedProperty().addListener((observable, oldValue, newValue) -> {
-            // exiting focus
-            if (!newValue) {
-                beginCountUpdateHelper();
-            }
-        });
+        detailView.getBeginCountField().focusedProperty().addListener(
+                (observable, oldValue, newValue) -> {
+                // exiting focus
+                if (!newValue) {
+                    beginCountUpdateHelper();
+                }
+            });
 
         detailView.getBeginCountField().setOnKeyPressed(event -> {
-            if (event.getCode().equals(KeyCode.ENTER)) {
-                beginCountUpdateHelper();
-            }
-        });
+                if (event.getCode().equals(KeyCode.ENTER)) {
+                    beginCountUpdateHelper();
+                }
+            });
     }
 
+    /**
+     * Format double into a nice displayable string.
+     * @param d - the double to format
+     * @return - a formatted string containng the double
+     */
     private String formatDouble(double d) {
         if (d == (long) d) {
             return String.format("%d", (long) d);
@@ -65,12 +64,17 @@ public class DetailViewController {
         }
     }
 
+    /**
+     * Helper for when the begincount field is edited.
+     * Parses entry to quarters and updates all the values
+     */
     private void beginCountUpdateHelper() {
         if (manager.getActiveShotBlock() != null) {
 
             String newValue = detailView.getBeginCountField().getText();
             double newVal = newValue.isEmpty() ? 0 : Double.parseDouble(newValue);
-            newVal = Math.round(newVal*4)/4f;
+            newVal = Math.round(newVal * numberOfCellsPerCount)
+                    / (double) numberOfCellsPerCount;
             detailView.getBeginCountField().setText(formatDouble(newVal));
 
             manager.getActiveShotBlock().setBeginCount(newVal);
@@ -87,26 +91,32 @@ public class DetailViewController {
     private void initEndCount() {
         detailView.setEndCount(0);
 
-        detailView.getEndCountField().focusedProperty().addListener((observable, oldValue, newValue) -> {
-            // exiting focus
-            if (!newValue) {
-                endCountUpdateHelper();
-            }
-        });
+        detailView.getEndCountField().focusedProperty().addListener(
+                (observable, oldValue, newValue) -> {
+                // exiting focus
+                if (!newValue) {
+                    endCountUpdateHelper();
+                }
+            });
 
         detailView.getEndCountField().setOnKeyPressed(event -> {
-            if (event.getCode().equals(KeyCode.ENTER)) {
-                endCountUpdateHelper();
-            }
-        });
+                if (event.getCode().equals(KeyCode.ENTER)) {
+                    endCountUpdateHelper();
+                }
+            });
     }
 
+    /**
+     * Helper for when the endcount field is edited.
+     * Parses entry to quarters and updates all the values
+     */
     private void endCountUpdateHelper() {
         if (manager.getActiveShotBlock() != null) {
 
             String newValue = detailView.getEndCountField().getText();
             double newVal = newValue.isEmpty() ? 0 : Double.parseDouble(newValue);
-            newVal = Math.round(newVal*4)/4f;
+            newVal = Math.round(newVal * numberOfCellsPerCount)
+                    / (double) numberOfCellsPerCount;
             detailView.getEndCountField().setText(formatDouble(newVal));
 
             manager.getActiveShotBlock().setEndCount(newVal);

--- a/src/main/java/control/DetailViewController.java
+++ b/src/main/java/control/DetailViewController.java
@@ -90,13 +90,13 @@ public class DetailViewController {
         detailView.getEndCountField().focusedProperty().addListener((observable, oldValue, newValue) -> {
             // exiting focus
             if (!newValue) {
-                beginCountUpdateHelper();
+                endCountUpdateHelper();
             }
         });
 
         detailView.getEndCountField().setOnKeyPressed(event -> {
             if (event.getCode().equals(KeyCode.ENTER)) {
-                beginCountUpdateHelper();
+                endCountUpdateHelper();
             }
         });
     }

--- a/src/main/java/control/DetailViewController.java
+++ b/src/main/java/control/DetailViewController.java
@@ -5,6 +5,14 @@ import data.ScriptingProject;
 import gui.centerarea.CameraShotBlock;
 import gui.headerarea.DetailView;
 import gui.centerarea.ShotBlock;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.event.EventHandler;
+import javafx.scene.input.DataFormat;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+
+import java.text.DecimalFormat;
 
 /**
  * Created by Bart.
@@ -35,17 +43,43 @@ public class DetailViewController {
     private void initBeginCount() {
         detailView.setBeginCount(0);
 
-        detailView.getBeginCountField().textProperty().addListener(
-                (observable, oldValue, newValue) -> {
-                if (manager.getActiveShotBlock() != null) {
-                    int newVal = !newValue.isEmpty() ? Integer.parseInt(newValue) : 0;
-                    manager.getActiveShotBlock().setBeginCount(newVal);
-                    if (manager.getActiveShotBlock() instanceof CameraShotBlock) {
-                        ((CameraShotBlock) manager.getActiveShotBlock()).getShot()
-                                .setBeginCount(newVal);
-                    }
-                }
-            });
+        detailView.getBeginCountField().focusedProperty().addListener((observable, oldValue, newValue) -> {
+            // exiting focus
+            if (!newValue) {
+                beginCountUpdateHelper();
+            }
+        });
+
+        detailView.getBeginCountField().setOnKeyPressed(event -> {
+            if (event.getCode().equals(KeyCode.ENTER)) {
+                beginCountUpdateHelper();
+            }
+        });
+    }
+
+    private String formatDouble(double d) {
+        if (d == (long) d) {
+            return String.format("%d", (long) d);
+        } else {
+            return String.format("%s", d);
+        }
+    }
+
+    private void beginCountUpdateHelper() {
+        if (manager.getActiveShotBlock() != null) {
+
+            String newValue = detailView.getBeginCountField().getText();
+            double newVal = newValue.isEmpty() ? 0 : Double.parseDouble(newValue);
+            newVal = Math.round(newVal*4)/4f;
+            detailView.getBeginCountField().setText(formatDouble(newVal));
+            System.out.println(formatDouble(newVal));
+
+            manager.getActiveShotBlock().setBeginCount(newVal);
+            if (manager.getActiveShotBlock() instanceof CameraShotBlock) {
+                ((CameraShotBlock) manager.getActiveShotBlock()).getShot()
+                        .setBeginCount(newVal);
+            }
+        }
     }
 
     /**

--- a/src/main/java/control/TimelineController.java
+++ b/src/main/java/control/TimelineController.java
@@ -76,7 +76,7 @@ public class TimelineController {
      * @param endCount End count.
      */
     public void addCameraShot(int cameraIndex, String name, String description,
-                              int startCount, int endCount) {
+                              double startCount, double endCount) {
         log.info("Adding CameraShot to Timeline");
 
         CameraShot newShot = new CameraShot(name,description, startCount, endCount);

--- a/src/main/java/control/ToolViewController.java
+++ b/src/main/java/control/ToolViewController.java
@@ -75,14 +75,14 @@ public class ToolViewController {
         // Add listeners for parsing to endfield
         creationModalView.getEndField().setOnKeyPressed(e -> {
                 if (e.getCode().equals(KeyCode.ENTER)) {
-                    creationModalView.getStartField().setText(
+                    creationModalView.getEndField().setText(
                             CountUtilities.parseCountNumber(creationModalView.getEndField().getText()));
                 }
             });
         creationModalView.getEndField().focusedProperty().addListener(
                 (observable, oldValue, newValue) -> {
                 if (!newValue) {
-                    creationModalView.getStartField().setText(
+                    creationModalView.getEndField().setText(
                             CountUtilities.parseCountNumber(creationModalView.getEndField().getText()));
                 }
             });

--- a/src/main/java/control/ToolViewController.java
+++ b/src/main/java/control/ToolViewController.java
@@ -20,8 +20,6 @@ public class ToolViewController {
     private ToolButton blockDeletionTool;
     private CreationModalView creationModalView;
 
-    private final int numberOfCellsPerCount = 4;
-
     /**
      * Constructor.
      * @param controllerManager Manager of the controllers.
@@ -62,65 +60,32 @@ public class ToolViewController {
         // Add listeners for parsing to startfield
         creationModalView.getStartField().setOnKeyPressed(e -> {
                 if (e.getCode().equals(KeyCode.ENTER)) {
-                    beginCountUpdateHelper();
+                    creationModalView.getStartField().setText(
+                            CountUtilities.parseCountNumber(creationModalView.getStartField().getText()));
                 }
             });
         creationModalView.getStartField().focusedProperty().addListener(
                 (observable, oldValue, newValue) -> {
                 if (!newValue) {
-                    beginCountUpdateHelper();
+                    creationModalView.getStartField().setText(
+                            CountUtilities.parseCountNumber(creationModalView.getStartField().getText()));
                 }
             });
 
         // Add listeners for parsing to endfield
         creationModalView.getEndField().setOnKeyPressed(e -> {
                 if (e.getCode().equals(KeyCode.ENTER)) {
-                    endCountUpdateHelper();
+                    creationModalView.getStartField().setText(
+                            CountUtilities.parseCountNumber(creationModalView.getEndField().getText()));
                 }
             });
         creationModalView.getEndField().focusedProperty().addListener(
                 (observable, oldValue, newValue) -> {
                 if (!newValue) {
-                    endCountUpdateHelper();
+                    creationModalView.getStartField().setText(
+                            CountUtilities.parseCountNumber(creationModalView.getEndField().getText()));
                 }
             });
-    }
-
-    /**
-     * Helper for when the begincount field is updated.
-     * Input is parsed to quarters here
-     */
-    private void beginCountUpdateHelper() {
-        String newValue = creationModalView.getStartField().getText();
-        double newVal = newValue.isEmpty() ? 0 : Double.parseDouble(newValue);
-        newVal = Math.round(newVal * numberOfCellsPerCount)
-                / (double) numberOfCellsPerCount;
-        creationModalView.getStartField().setText(formatDouble(newVal));
-    }
-
-    /**
-     * Helper for when the endcount field is updated.
-     * Input is parsed to quarters here
-     */
-    private void endCountUpdateHelper() {
-        String newValue = creationModalView.getEndField().getText();
-        double newVal = newValue.isEmpty() ? 0 : Double.parseDouble(newValue);
-        newVal = Math.round(newVal * numberOfCellsPerCount)
-                / (double) numberOfCellsPerCount;
-        creationModalView.getEndField().setText(formatDouble(newVal));
-    }
-
-    /**
-     * Format double into a nice displayable string.
-     * @param d - the double to format
-     * @return - a formatted string containng the double
-     */
-    private String formatDouble(double d) {
-        if (d == (long) d) {
-            return String.format("%d", (long) d);
-        } else {
-            return String.format("%s", d);
-        }
     }
 
     /**

--- a/src/main/java/control/ToolViewController.java
+++ b/src/main/java/control/ToolViewController.java
@@ -6,8 +6,6 @@ import gui.modal.CreationModalView;
 import gui.events.DirectorShotCreationEvent;
 import gui.centerarea.ShotBlock;
 import gui.headerarea.ToolButton;
-import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseEvent;
 
@@ -21,6 +19,8 @@ public class ToolViewController {
     private ToolButton blockCreationTool;
     private ToolButton blockDeletionTool;
     private CreationModalView creationModalView;
+
+    private final int numberOfCellsPerCount = 4;
 
     /**
      * Constructor.
@@ -61,43 +61,60 @@ public class ToolViewController {
 
         // Add listeners for parsing to startfield
         creationModalView.getStartField().setOnKeyPressed(e -> {
-            if (e.getCode().equals(KeyCode.ENTER)) {
-                beginCountUpdateHelper();
-            }
-        });
-        creationModalView.getStartField().focusedProperty().addListener((observable, oldValue, newValue) -> {
-            if (!newValue) {
-                beginCountUpdateHelper();
-            }
-        });
+                if (e.getCode().equals(KeyCode.ENTER)) {
+                    beginCountUpdateHelper();
+                }
+            });
+        creationModalView.getStartField().focusedProperty().addListener(
+                (observable, oldValue, newValue) -> {
+                if (!newValue) {
+                    beginCountUpdateHelper();
+                }
+            });
 
         // Add listeners for parsing to endfield
         creationModalView.getEndField().setOnKeyPressed(e -> {
-            if (e.getCode().equals(KeyCode.ENTER)) {
-                endCountUpdateHelper();
-            }
-        });
-        creationModalView.getEndField().focusedProperty().addListener((observable, oldValue, newValue) -> {
-            if (!newValue) {
-                endCountUpdateHelper();
-            }
-        });
+                if (e.getCode().equals(KeyCode.ENTER)) {
+                    endCountUpdateHelper();
+                }
+            });
+        creationModalView.getEndField().focusedProperty().addListener(
+                (observable, oldValue, newValue) -> {
+                if (!newValue) {
+                    endCountUpdateHelper();
+                }
+            });
     }
 
+    /**
+     * Helper for when the begincount field is updated.
+     * Input is parsed to quarters here
+     */
     private void beginCountUpdateHelper() {
         String newValue = creationModalView.getStartField().getText();
         double newVal = newValue.isEmpty() ? 0 : Double.parseDouble(newValue);
-        newVal = Math.round(newVal * 4) / 4f;
+        newVal = Math.round(newVal * numberOfCellsPerCount)
+                / (double) numberOfCellsPerCount;
         creationModalView.getStartField().setText(formatDouble(newVal));
     }
 
+    /**
+     * Helper for when the endcount field is updated.
+     * Input is parsed to quarters here
+     */
     private void endCountUpdateHelper() {
         String newValue = creationModalView.getEndField().getText();
         double newVal = newValue.isEmpty() ? 0 : Double.parseDouble(newValue);
-        newVal = Math.round(newVal * 4) / 4f;
+        newVal = Math.round(newVal * numberOfCellsPerCount)
+                / (double) numberOfCellsPerCount;
         creationModalView.getEndField().setText(formatDouble(newVal));
     }
 
+    /**
+     * Format double into a nice displayable string.
+     * @param d - the double to format
+     * @return - a formatted string containng the double
+     */
     private String formatDouble(double d) {
         if (d == (long) d) {
             return String.format("%d", (long) d);

--- a/src/main/java/control/ToolViewController.java
+++ b/src/main/java/control/ToolViewController.java
@@ -61,14 +61,16 @@ public class ToolViewController {
         creationModalView.getStartField().setOnKeyPressed(e -> {
                 if (e.getCode().equals(KeyCode.ENTER)) {
                     creationModalView.getStartField().setText(
-                            CountUtilities.parseCountNumber(creationModalView.getStartField().getText()));
+                            CountUtilities.parseCountNumber(
+                                    creationModalView.getStartField().getText()));
                 }
             });
         creationModalView.getStartField().focusedProperty().addListener(
                 (observable, oldValue, newValue) -> {
                 if (!newValue) {
                     creationModalView.getStartField().setText(
-                            CountUtilities.parseCountNumber(creationModalView.getStartField().getText()));
+                            CountUtilities.parseCountNumber(
+                                    creationModalView.getStartField().getText()));
                 }
             });
 
@@ -76,14 +78,16 @@ public class ToolViewController {
         creationModalView.getEndField().setOnKeyPressed(e -> {
                 if (e.getCode().equals(KeyCode.ENTER)) {
                     creationModalView.getEndField().setText(
-                            CountUtilities.parseCountNumber(creationModalView.getEndField().getText()));
+                            CountUtilities.parseCountNumber(
+                                    creationModalView.getEndField().getText()));
                 }
             });
         creationModalView.getEndField().focusedProperty().addListener(
                 (observable, oldValue, newValue) -> {
                 if (!newValue) {
                     creationModalView.getEndField().setText(
-                            CountUtilities.parseCountNumber(creationModalView.getEndField().getText()));
+                            CountUtilities.parseCountNumber(
+                                    creationModalView.getEndField().getText()));
                 }
             });
     }

--- a/src/main/java/data/CameraShot.java
+++ b/src/main/java/data/CameraShot.java
@@ -29,7 +29,7 @@ public class CameraShot extends Shot {
      * @param startCount the count the Shot starts
      * @param endCount the count the Shot ends
      */
-    public CameraShot(String name, String description, int startCount, int endCount) {
+    public CameraShot(String name, String description, double startCount, double endCount) {
         super(instanceCounter, name, description, startCount, endCount);
         log.debug("Created new CameraShot");
         instanceCounter++;

--- a/src/main/java/data/DirectorShot.java
+++ b/src/main/java/data/DirectorShot.java
@@ -31,7 +31,7 @@ public class DirectorShot extends Shot {
      * @param startCount the start count of the Shot
      * @param endCount the end count of the Shot
      */
-    public DirectorShot(String name, String description, int startCount, int endCount) {
+    public DirectorShot(String name, String description, double startCount, double endCount) {
         super(instanceCounter, name, description, startCount, endCount);
         log.debug("Created new DirectorShot");
         instanceCounter++;

--- a/src/main/java/data/DirectorTimeline.java
+++ b/src/main/java/data/DirectorTimeline.java
@@ -56,7 +56,7 @@ public class DirectorTimeline extends Timeline {
      * @see DirectorTimeline#addShot(DirectorShot)
      */
     public ArrayList<DirectorShot> addShot(String name, String description,
-                                           int startCount, int endCount) {
+                                           double startCount, double endCount) {
         return addShot(new DirectorShot(name, description, startCount, endCount));
     }
 

--- a/src/main/java/data/Shot.java
+++ b/src/main/java/data/Shot.java
@@ -63,7 +63,7 @@ public abstract class Shot {
      * @param beginCount the start count of the Shot
      * @param endCount the end count of the Shot
      */
-    public Shot(int instance, String name, String description, int beginCount, int endCount) {
+    public Shot(int instance, String name, String description, double beginCount, double endCount) {
         log.debug("Adding Shot(instance={}, name={}, description={}, beginCount={}, endCount={})",
                 instance, name, description, beginCount, endCount);
 

--- a/src/main/java/gui/centerarea/CameraShotBlock.java
+++ b/src/main/java/gui/centerarea/CameraShotBlock.java
@@ -54,10 +54,6 @@ public class CameraShotBlock extends ShotBlock {
         this.grid = rootCenterArea.getMainTimeLineGridPane();
 
         this.getTimetableBlock().addEventHandler(ShotblockUpdatedEvent.SHOTBLOCK_UPDATED, e -> {
-//                this.setBeginCount(TimelinesGridPane.getRowIndex(
-//                        this.getTimetableBlock()) / 4f, false);
-//                this.setEndCount((TimelinesGridPane.getRowSpan(
-//                    this.getTimetableBlock()) + this.getBeginCount()) / 4f, false);
                 this.timetableNumber = TimelinesGridPane.getColumnIndex(
                     this.getTimetableBlock());
 

--- a/src/main/java/gui/centerarea/CameraShotBlock.java
+++ b/src/main/java/gui/centerarea/CameraShotBlock.java
@@ -55,9 +55,9 @@ public class CameraShotBlock extends ShotBlock {
 
         this.getTimetableBlock().addEventHandler(ShotblockUpdatedEvent.SHOTBLOCK_UPDATED, e -> {
                 this.setBeginCount(TimelinesGridPane.getRowIndex(
-                        this.getTimetableBlock()), false);
-                this.setEndCount(TimelinesGridPane.getRowSpan(
-                    this.getTimetableBlock()) + this.getBeginCount(), false);
+                        this.getTimetableBlock())/4f, false);
+                this.setEndCount((TimelinesGridPane.getRowSpan(
+                    this.getTimetableBlock()) + this.getBeginCount()) /4f, false);
                 this.timetableNumber = TimelinesGridPane.getColumnIndex(
                     this.getTimetableBlock());
 

--- a/src/main/java/gui/centerarea/CameraShotBlock.java
+++ b/src/main/java/gui/centerarea/CameraShotBlock.java
@@ -54,10 +54,10 @@ public class CameraShotBlock extends ShotBlock {
         this.grid = rootCenterArea.getMainTimeLineGridPane();
 
         this.getTimetableBlock().addEventHandler(ShotblockUpdatedEvent.SHOTBLOCK_UPDATED, e -> {
-                this.setBeginCount(TimelinesGridPane.getRowIndex(
-                        this.getTimetableBlock())/4f, false);
-                this.setEndCount((TimelinesGridPane.getRowSpan(
-                    this.getTimetableBlock()) + this.getBeginCount()) /4f, false);
+//                this.setBeginCount(TimelinesGridPane.getRowIndex(
+//                        this.getTimetableBlock()) / 4f, false);
+//                this.setEndCount((TimelinesGridPane.getRowSpan(
+//                    this.getTimetableBlock()) + this.getBeginCount()) / 4f, false);
                 this.timetableNumber = TimelinesGridPane.getColumnIndex(
                     this.getTimetableBlock());
 

--- a/src/main/java/gui/centerarea/CounterGridPane.java
+++ b/src/main/java/gui/centerarea/CounterGridPane.java
@@ -62,8 +62,8 @@ public class CounterGridPane extends ScrollableGridPane {
      * @param verticalElementSize size of usual vertical elements.
      */
     private void initGridNumbers(int numberOfCounts, int verticalElementSize) {
-        for (int i = 4; i < numberOfCounts; i +=4) {
-            Label label = new Label(Integer.toString(i/4));
+        for (int i = 4; i < numberOfCounts; i += 4) {
+            Label label = new Label(Integer.toString(i / 4));
             label.setStyle(labelStyle);
             setHalignment(label, HPos.RIGHT);
             this.add(label, 0, i);

--- a/src/main/java/gui/centerarea/CounterGridPane.java
+++ b/src/main/java/gui/centerarea/CounterGridPane.java
@@ -63,7 +63,7 @@ public class CounterGridPane extends ScrollableGridPane {
      * @param verticalElementSize size of usual vertical elements.
      */
     private void initGridNumbers(int numberOfCounts, int verticalElementSize) {
-        int cellsPerCount = CountUtilities.numberOfCellsPerCount;
+        int cellsPerCount = CountUtilities.NUMBER_OF_CELLS_PER_COUNT;
         for (int i = cellsPerCount; i < numberOfCounts; i += cellsPerCount) {
             Label label = new Label(Integer.toString(i / cellsPerCount));
             label.setStyle(labelStyle);

--- a/src/main/java/gui/centerarea/CounterGridPane.java
+++ b/src/main/java/gui/centerarea/CounterGridPane.java
@@ -1,5 +1,6 @@
 package gui.centerarea;
 
+import control.CountUtilities;
 import javafx.geometry.HPos;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Priority;
@@ -62,8 +63,9 @@ public class CounterGridPane extends ScrollableGridPane {
      * @param verticalElementSize size of usual vertical elements.
      */
     private void initGridNumbers(int numberOfCounts, int verticalElementSize) {
-        for (int i = 4; i < numberOfCounts; i += 4) {
-            Label label = new Label(Integer.toString(i / 4));
+        int cellsPerCount = CountUtilities.numberOfCellsPerCount;
+        for (int i = cellsPerCount; i < numberOfCounts; i += cellsPerCount) {
+            Label label = new Label(Integer.toString(i / cellsPerCount));
             label.setStyle(labelStyle);
             setHalignment(label, HPos.RIGHT);
             this.add(label, 0, i);

--- a/src/main/java/gui/centerarea/CounterGridPane.java
+++ b/src/main/java/gui/centerarea/CounterGridPane.java
@@ -62,8 +62,8 @@ public class CounterGridPane extends ScrollableGridPane {
      * @param verticalElementSize size of usual vertical elements.
      */
     private void initGridNumbers(int numberOfCounts, int verticalElementSize) {
-        for (int i = 4; i < numberOfCounts; i += 4) {
-            Label label = new Label(Integer.toString(i));
+        for (int i = 4; i < numberOfCounts; i +=4) {
+            Label label = new Label(Integer.toString(i/4));
             label.setStyle(labelStyle);
             setHalignment(label, HPos.RIGHT);
             this.add(label, 0, i);

--- a/src/main/java/gui/centerarea/ShotBlock.java
+++ b/src/main/java/gui/centerarea/ShotBlock.java
@@ -179,9 +179,9 @@ public abstract class ShotBlock {
      */
     public void recompute() {
         TimelinesGridPane.setRowIndex(timetableBlock,
-                (int) Math.round(beginCount));
+                (int) Math.round(beginCount * 4));
         TimelinesGridPane.setRowSpan(timetableBlock,
-                (int) Math.round(endCount - beginCount));
+                (int) Math.round((endCount - beginCount) * 4));
     }
 
     /**

--- a/src/main/java/gui/centerarea/ShotBlock.java
+++ b/src/main/java/gui/centerarea/ShotBlock.java
@@ -105,7 +105,7 @@ public abstract class ShotBlock {
      * @param recompute - should we recompute after setting
      */
     public void setBeginCount(double count, boolean recompute) {
-        if (count <= this.endCount - 1) {
+        if (count <= this.endCount - 1 || !recompute) {
             this.beginCount = count;
         }
         if (recompute) {
@@ -128,7 +128,7 @@ public abstract class ShotBlock {
      * @param recompute - should we recompute after setting
      */
     public void setEndCount(double count, boolean recompute) {
-        if (count >= this.beginCount + 1) {
+        if (count >= this.beginCount + 1 || !recompute) {
             this.endCount = count;
         }
         if (recompute) {

--- a/src/main/java/gui/centerarea/TimelinesGridPane.java
+++ b/src/main/java/gui/centerarea/TimelinesGridPane.java
@@ -1,6 +1,8 @@
 package gui.centerarea;
 
 import java.util.ArrayList;
+
+import control.CountUtilities;
 import javafx.geometry.Bounds;
 import javafx.geometry.Insets;
 
@@ -9,9 +11,7 @@ import javafx.geometry.Insets;
  */
 public class TimelinesGridPane extends ScrollableGridPane {
 
-
     private ArrayList<SnappingPane> panes;
-    private int gridLineSkips = 4;
 
     /**
      * Constructor.
@@ -41,8 +41,8 @@ public class TimelinesGridPane extends ScrollableGridPane {
      */
     public void addCameraShotBlock(CameraShotBlock block) {
         this.add(block.getTimetableBlock(), block.getTimetableNumber(),
-                (int) Math.round(block.getBeginCount() * 4), 1,
-                (int) Math.round((block.getEndCount() - block.getBeginCount()) * 4));
+                (int) Math.round(block.getBeginCount() * CountUtilities.numberOfCellsPerCount), 1,
+                (int) Math.round((block.getEndCount() - block.getBeginCount()) * CountUtilities.numberOfCellsPerCount));
     }
 
     /**
@@ -65,7 +65,7 @@ public class TimelinesGridPane extends ScrollableGridPane {
                 SnappingPane pane = new SnappingPane(j, i);
                 this.add(pane, i, j);
                 panes.add(pane);
-                if (c > gridLineSkips) {
+                if (c > CountUtilities.numberOfCellsPerCount) {
                     pane.getStyleClass().add("timeline_Background_Lines");
                     c = 2;
                 } else {

--- a/src/main/java/gui/centerarea/TimelinesGridPane.java
+++ b/src/main/java/gui/centerarea/TimelinesGridPane.java
@@ -41,8 +41,8 @@ public class TimelinesGridPane extends ScrollableGridPane {
      */
     public void addCameraShotBlock(CameraShotBlock block) {
         this.add(block.getTimetableBlock(), block.getTimetableNumber(),
-                (int) Math.round(block.getBeginCount() * CountUtilities.NUMBER_OF_CELLS_PER_COUNT), 1,
-                (int) Math.round((block.getEndCount()
+                (int) Math.round(block.getBeginCount() * CountUtilities.NUMBER_OF_CELLS_PER_COUNT),
+                1, (int) Math.round((block.getEndCount()
                         - block.getBeginCount()) * CountUtilities.NUMBER_OF_CELLS_PER_COUNT));
     }
 

--- a/src/main/java/gui/centerarea/TimelinesGridPane.java
+++ b/src/main/java/gui/centerarea/TimelinesGridPane.java
@@ -41,8 +41,8 @@ public class TimelinesGridPane extends ScrollableGridPane {
      */
     public void addCameraShotBlock(CameraShotBlock block) {
         this.add(block.getTimetableBlock(), block.getTimetableNumber(),
-                (int) Math.round(block.getBeginCount()), 1,
-                (int) Math.round(block.getEndCount() - block.getBeginCount()));
+                (int) Math.round(block.getBeginCount() * 4), 1,
+                (int) Math.round((block.getEndCount() - block.getBeginCount()) * 4));
     }
 
     /**

--- a/src/main/java/gui/centerarea/TimelinesGridPane.java
+++ b/src/main/java/gui/centerarea/TimelinesGridPane.java
@@ -42,7 +42,8 @@ public class TimelinesGridPane extends ScrollableGridPane {
     public void addCameraShotBlock(CameraShotBlock block) {
         this.add(block.getTimetableBlock(), block.getTimetableNumber(),
                 (int) Math.round(block.getBeginCount() * CountUtilities.numberOfCellsPerCount), 1,
-                (int) Math.round((block.getEndCount() - block.getBeginCount()) * CountUtilities.numberOfCellsPerCount));
+                (int) Math.round((block.getEndCount()
+                        - block.getBeginCount()) * CountUtilities.numberOfCellsPerCount));
     }
 
     /**

--- a/src/main/java/gui/centerarea/TimelinesGridPane.java
+++ b/src/main/java/gui/centerarea/TimelinesGridPane.java
@@ -41,9 +41,9 @@ public class TimelinesGridPane extends ScrollableGridPane {
      */
     public void addCameraShotBlock(CameraShotBlock block) {
         this.add(block.getTimetableBlock(), block.getTimetableNumber(),
-                (int) Math.round(block.getBeginCount() * CountUtilities.numberOfCellsPerCount), 1,
+                (int) Math.round(block.getBeginCount() * CountUtilities.NUMBER_OF_CELLS_PER_COUNT), 1,
                 (int) Math.round((block.getEndCount()
-                        - block.getBeginCount()) * CountUtilities.numberOfCellsPerCount));
+                        - block.getBeginCount()) * CountUtilities.NUMBER_OF_CELLS_PER_COUNT));
     }
 
     /**
@@ -66,7 +66,7 @@ public class TimelinesGridPane extends ScrollableGridPane {
                 SnappingPane pane = new SnappingPane(j, i);
                 this.add(pane, i, j);
                 panes.add(pane);
-                if (c > CountUtilities.numberOfCellsPerCount) {
+                if (c > CountUtilities.NUMBER_OF_CELLS_PER_COUNT) {
                     pane.getStyleClass().add("timeline_Background_Lines");
                     c = 2;
                 } else {

--- a/src/main/java/gui/centerarea/TimetableBlock.java
+++ b/src/main/java/gui/centerarea/TimetableBlock.java
@@ -1,5 +1,6 @@
 package gui.centerarea;
 
+import control.CountUtilities;
 import gui.misc.BlurHelper;
 import gui.root.RootCenterArea;
 import javafx.event.EventHandler;
@@ -45,8 +46,6 @@ public abstract class TimetableBlock extends Pane {
     private double verticalBorderSize = 4.0;
     private double margin = 5.0;
     private double blurRadius = 20.0;
-
-    private final int numberOfCellsPerCount = 4;
 
     /**
      *  Content variables.
@@ -379,10 +378,10 @@ public abstract class TimetableBlock extends Pane {
 
             // Update ShotBlock
             double newBeginCount = TimelinesGridPane.getRowIndex(thisBlock)
-                    / (double) numberOfCellsPerCount;
+                    / (double) CountUtilities.numberOfCellsPerCount;
             parentBlock.setBeginCount(newBeginCount, false);
             parentBlock.setEndCount(newBeginCount + TimelinesGridPane.getRowSpan(thisBlock)
-                    / (double) numberOfCellsPerCount, false);
+                    / (double) CountUtilities.numberOfCellsPerCount, false);
 
             this.fireEvent(parentBlock.getShotBlockUpdatedEvent());
         };

--- a/src/main/java/gui/centerarea/TimetableBlock.java
+++ b/src/main/java/gui/centerarea/TimetableBlock.java
@@ -46,6 +46,8 @@ public abstract class TimetableBlock extends Pane {
     private double margin = 5.0;
     private double blurRadius = 20.0;
 
+    private final int numberOfCellsPerCount = 4;
+
     /**
      *  Content variables.
      *  Directly displaying block content, such as the name.
@@ -376,9 +378,11 @@ public abstract class TimetableBlock extends Pane {
             snapPane(thisBlock, draggedPane, e.getSceneX(), e.getSceneY(), draggingType);
 
             // Update ShotBlock
-            double newBeginCount = TimelinesGridPane.getRowIndex(thisBlock)/4f;
+            double newBeginCount = TimelinesGridPane.getRowIndex(thisBlock)
+                    / (double) numberOfCellsPerCount;
             parentBlock.setBeginCount(newBeginCount, false);
-            parentBlock.setEndCount(newBeginCount + TimelinesGridPane.getRowSpan(thisBlock)/4f, false);
+            parentBlock.setEndCount(newBeginCount + TimelinesGridPane.getRowSpan(thisBlock)
+                    / (double) numberOfCellsPerCount, false);
 
             this.fireEvent(parentBlock.getShotBlockUpdatedEvent());
         };

--- a/src/main/java/gui/centerarea/TimetableBlock.java
+++ b/src/main/java/gui/centerarea/TimetableBlock.java
@@ -255,7 +255,7 @@ public abstract class TimetableBlock extends Pane {
      * @return the label in question.
      */
     private Label initCountLabel(VBox vbox) {
-        String labelText = parentBlock.getBeginCount()/4 + " - " + parentBlock.getEndCount()/4;
+        String labelText = parentBlock.getBeginCount() + " - " + parentBlock.getEndCount();
         Label res = new Label(labelText);
         res.maxWidthProperty().bind(this.widthProperty());
         res.getStyleClass().add("block_Text_Normal");

--- a/src/main/java/gui/centerarea/TimetableBlock.java
+++ b/src/main/java/gui/centerarea/TimetableBlock.java
@@ -255,7 +255,7 @@ public abstract class TimetableBlock extends Pane {
      * @return the label in question.
      */
     private Label initCountLabel(VBox vbox) {
-        String labelText = parentBlock.getBeginCount() + " - " + parentBlock.getEndCount();
+        String labelText = parentBlock.getBeginCount()/4 + " - " + parentBlock.getEndCount()/4;
         Label res = new Label(labelText);
         res.maxWidthProperty().bind(this.widthProperty());
         res.getStyleClass().add("block_Text_Normal");

--- a/src/main/java/gui/centerarea/TimetableBlock.java
+++ b/src/main/java/gui/centerarea/TimetableBlock.java
@@ -378,10 +378,10 @@ public abstract class TimetableBlock extends Pane {
 
             // Update ShotBlock
             double newBeginCount = TimelinesGridPane.getRowIndex(thisBlock)
-                    / (double) CountUtilities.numberOfCellsPerCount;
+                    / (double) CountUtilities.NUMBER_OF_CELLS_PER_COUNT;
             parentBlock.setBeginCount(newBeginCount, false);
             parentBlock.setEndCount(newBeginCount + TimelinesGridPane.getRowSpan(thisBlock)
-                    / (double) CountUtilities.numberOfCellsPerCount, false);
+                    / (double) CountUtilities.NUMBER_OF_CELLS_PER_COUNT, false);
 
             this.fireEvent(parentBlock.getShotBlockUpdatedEvent());
         };

--- a/src/main/java/gui/centerarea/TimetableBlock.java
+++ b/src/main/java/gui/centerarea/TimetableBlock.java
@@ -376,9 +376,9 @@ public abstract class TimetableBlock extends Pane {
             snapPane(thisBlock, draggedPane, e.getSceneX(), e.getSceneY(), draggingType);
 
             // Update ShotBlock
-            int newBeginCount = TimelinesGridPane.getRowIndex(thisBlock);
+            double newBeginCount = TimelinesGridPane.getRowIndex(thisBlock)/4f;
             parentBlock.setBeginCount(newBeginCount, false);
-            parentBlock.setEndCount(newBeginCount + TimelinesGridPane.getRowSpan(thisBlock), false);
+            parentBlock.setEndCount(newBeginCount + TimelinesGridPane.getRowSpan(thisBlock)/4f, false);
 
             this.fireEvent(parentBlock.getShotBlockUpdatedEvent());
         };

--- a/src/main/java/gui/headerarea/DetailView.java
+++ b/src/main/java/gui/headerarea/DetailView.java
@@ -32,10 +32,10 @@ public class DetailView extends VBox {
     private TextField descriptionField;
 
     @Getter
-    private NumberTextField beginCountField;
+    private DoubleTextField beginCountField;
 
     @Getter
-    private NumberTextField endCountField;
+    private DoubleTextField endCountField;
 
     /**
      * Constructor.
@@ -95,7 +95,7 @@ public class DetailView extends VBox {
      * Init the begincount part of the detailview.
      */
     private  void initBeginCount() {
-        beginCountField = new NumberTextField();
+        beginCountField = new DoubleTextField();
         beginCountField.setText("123");
         beginCountField.setPrefWidth(50);
 
@@ -110,7 +110,7 @@ public class DetailView extends VBox {
      * Init the endcount part of the detailview.
      */
     private  void initEndCount() {
-        endCountField = new NumberTextField();
+        endCountField = new DoubleTextField();
         endCountField.setText("123");
         endCountField.setPrefWidth(50);
 

--- a/src/main/java/gui/headerarea/DetailView.java
+++ b/src/main/java/gui/headerarea/DetailView.java
@@ -75,6 +75,11 @@ public class DetailView extends VBox {
         nameField.setText(name);
     }
 
+    /**
+     * Format double into a nice displayable string.
+     * @param d - the double to format
+     * @return - a formatted string containng the double
+     */
     private String formatDouble(double d) {
         if (d == (long) d) {
             return String.format("%d", (long) d);

--- a/src/main/java/gui/headerarea/DetailView.java
+++ b/src/main/java/gui/headerarea/DetailView.java
@@ -75,20 +75,28 @@ public class DetailView extends VBox {
         nameField.setText(name);
     }
 
+    private String formatDouble(double d) {
+        if (d == (long) d) {
+            return String.format("%d", (long) d);
+        } else {
+            return String.format("%s", d);
+        }
+    }
+
     /**
      * Set the begincount of the detailview.
      * @param count - the count to set
      */
-    public void setBeginCount(int count) {
-        beginCountField.setText(String.format("%d", count));
+    public void setBeginCount(double count) {
+        beginCountField.setText(formatDouble(count));
     }
 
     /**
      * Set the endcount of the detailview.
      * @param count - the count to set
      */
-    public void setEndCount(int count) {
-        endCountField.setText(String.format("%d", count));
+    public void setEndCount(double count) {
+        endCountField.setText(formatDouble(count));
     }
 
     /**

--- a/src/main/java/gui/headerarea/DoubleTextField.java
+++ b/src/main/java/gui/headerarea/DoubleTextField.java
@@ -1,0 +1,32 @@
+package gui.headerarea;
+
+import javafx.scene.control.TextField;
+
+import java.text.DecimalFormat;
+
+/**
+ * Created by Bart.
+ */
+public class DoubleTextField extends TextField {
+
+    @Override
+    public void replaceText(int start, int end, String text) {
+        String newText = this.getText().substring(0, start) + text
+                + this.getText().substring(end, this.getText().length());
+
+        if (validate(newText)) {
+            super.replaceText(start, end, text);
+        }
+    }
+
+    @Override
+    public void replaceSelection(String text) {
+        if (validate(this.getText())) {
+            super.replaceSelection(text);
+        }
+    }
+
+    private boolean validate(String text) {
+        return text.matches("[0-9]*[.]?[0-9]*");
+    }
+}

--- a/src/main/java/gui/modal/CreationModalView.java
+++ b/src/main/java/gui/modal/CreationModalView.java
@@ -1,5 +1,6 @@
 package gui.modal;
 
+import gui.headerarea.DoubleTextField;
 import gui.root.RootPane;
 import gui.events.DirectorShotCreationEvent;
 import gui.headerarea.NumberTextField;
@@ -13,6 +14,7 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Text;
+import lombok.Getter;
 import lombok.Setter;
 
 import java.util.ArrayList;
@@ -38,10 +40,13 @@ public class CreationModalView extends ModalView {
     private List<CheckBox> cameraCheckboxes;
     private TextField descripField;
     private TextField nameField;
-    private NumberTextField startField;
-    private NumberTextField endField;
-    private Button creationButton;
 
+    @Getter
+    private DoubleTextField startField;
+    @Getter
+    private DoubleTextField endField;
+
+    private Button creationButton;
     private EventHandler<DirectorShotCreationEvent> shotCreationEventHandler;
 
     /**
@@ -118,9 +123,9 @@ public class CreationModalView extends ModalView {
     private void initCountFields() {
         // Start and end points
         final Label startLabel = new Label("Start:");
-        startField = new NumberTextField();
+        startField = new DoubleTextField();
         final Label endLabel = new Label("End:");
-        endField = new NumberTextField();
+        endField = new DoubleTextField();
 
         // Add default values as a cue
         startField.setText(this.defaultStartCount);


### PR DESCRIPTION
Changed all int counter stuff to quarters (4 grid cells per count).
That means the input in some textfields is parsed to quarters when exiting focus or pressing enter, and converting these doubles to the right cells in the grid pane.
