### PR TITLE
Issue fixes

### DIFF
--- a/src/main/java/control/ControllerManager.java
+++ b/src/main/java/control/ControllerManager.java
@@ -1,13 +1,21 @@
 package control;
 
+import java.beans.PropertyChangeEvent;
+
+import java.awt.KeyboardFocusManager;
+
 import data.ScriptingProject;
 import gui.centerarea.ShotBlock;
 import gui.modal.SaveModalView;
 import gui.root.RootPane;
 import javafx.scene.input.MouseEvent;
 import javafx.stage.WindowEvent;
+import javafx.application.Platform;
+import javafx.scene.Node;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
+import javafx.beans.value.ObservableValue;
+import javafx.scene.control.TextField;
 
 /**
  * Class wrapper for model management controllers.
@@ -55,6 +63,7 @@ public class ControllerManager {
         this.rootPane = rootPane;
         initializeControllers();
         initOnCloseOperation();
+        initTextFieldAutoSelect();
     }
 
     /**
@@ -92,6 +101,27 @@ public class ControllerManager {
         preferencesViewController = new PreferencesViewController(this);
         toolViewController = new ToolViewController(this);
         projectController = new ProjectController(this);
+    }
+    
+    private void initTextFieldAutoSelect() {
+        System.out.println("INITED");
+        rootPane.getPrimaryStage().getScene().focusOwnerProperty().addListener(this::focusChangeListener);
+    }
+    
+    private void focusChangeListener(ObservableValue<? extends Node> observable, Node oldValue, Node newValue) {
+        if (newValue != null) {
+            System.out.println("CLASS NAME NEW VALUE " + newValue.getClass().getName());
+            String className = newValue.getClass().getName();
+            if (className.equals("gui.styling.StyledTextfield")
+                    || className.equals("gui.headerarea.NumberTextField")
+                    || className.equals("gui.headerarea.DoubleTextField")
+                    || className.equals("javafx.scene.control.TextField")) {
+                
+                Platform.runLater(() -> {
+                    ((TextField) newValue).selectAll();
+                });
+            }
+        }
     }
 
     /**

--- a/src/main/java/control/ControllerManager.java
+++ b/src/main/java/control/ControllerManager.java
@@ -103,14 +103,24 @@ public class ControllerManager {
         projectController = new ProjectController(this);
     }
     
+    /**
+     * Init the handler for auto text select for text fields.
+     */
     private void initTextFieldAutoSelect() {
-        System.out.println("INITED");
-        rootPane.getPrimaryStage().getScene().focusOwnerProperty().addListener(this::focusChangeListener);
+        rootPane.getPrimaryStage().getScene().focusOwnerProperty()
+            .addListener(this::focusChangeListener);
     }
     
-    private void focusChangeListener(ObservableValue<? extends Node> observable, Node oldValue, Node newValue) {
+    /**
+     * Handler for auto text select.
+     Checks if the new selected Node is a text field, and selects text if needed
+     * @param observable the observable value
+     * @param oldValue the old node
+     * @param newValue the new node
+     */
+    private void focusChangeListener(ObservableValue<? extends Node> observable,
+            Node oldValue, Node newValue) {
         if (newValue != null) {
-            System.out.println("CLASS NAME NEW VALUE " + newValue.getClass().getName());
             String className = newValue.getClass().getName();
             if (className.equals("gui.styling.StyledTextfield")
                     || className.equals("gui.headerarea.NumberTextField")
@@ -118,8 +128,8 @@ public class ControllerManager {
                     || className.equals("javafx.scene.control.TextField")) {
                 
                 Platform.runLater(() -> {
-                    ((TextField) newValue).selectAll();
-                });
+                        ((TextField) newValue).selectAll();
+                    });
             }
         }
     }

--- a/src/main/java/control/CreationModalViewController.java
+++ b/src/main/java/control/CreationModalViewController.java
@@ -325,17 +325,6 @@ public class CreationModalViewController {
 
         errorString = validateDirectorShotCounts(errorString);
 
-        boolean aCameraSelected = false;
-        for (CheckBox cb : directorShotCreationModalView.getCameraCheckboxes()) {
-            if (cb.isSelected()) {
-                aCameraSelected = true;
-            }
-        }
-
-        if (!aCameraSelected) {
-            errorString += "Please select at least one camera for this shot.";
-        }
-
         if (errorString.isEmpty()) {
             return true;
         } else {

--- a/src/main/java/control/CreationModalViewController.java
+++ b/src/main/java/control/CreationModalViewController.java
@@ -139,7 +139,7 @@ public class CreationModalViewController {
                 });
 
             cameraShotCreationModalView.getCamerasInShot().forEach(cameraIndex -> {
-                    timelineController.addCameraShot(cameraIndex, shot);
+                    timelineController.addCameraShot(cameraIndex, shot.clone());
                 });
 
             cameraShotCreationModalView.getModalStage().close();

--- a/src/main/java/control/DetailViewController.java
+++ b/src/main/java/control/DetailViewController.java
@@ -265,6 +265,8 @@ public class DetailViewController {
         manager.getTimelineControl().removeCameraShot(toRemove);
         dShot.getCameraShots().remove(toRemove);
         dShot.getTimelineIndices().remove(index);
+        manager.getTimelineControl().recomputeAllCollisions();
+        manager.getDirectorTimelineControl().recomputeAllCollisions();
     }
     
     /**
@@ -289,6 +291,8 @@ public class DetailViewController {
         manager.getScriptingProject().getCameraTimelines().get(index).addShot(shot);
         manager.getTimelineControl().initShotBlock(index, shot, false);
         manager.setActiveShotBlock(dShotBlock);
+        manager.getTimelineControl().recomputeAllCollisions();
+        manager.getDirectorTimelineControl().recomputeAllCollisions();
     }
 
     /**

--- a/src/main/java/control/ProjectController.java
+++ b/src/main/java/control/ProjectController.java
@@ -353,6 +353,7 @@ public class ProjectController {
             CameraShot.setInstanceCounter(maxInstance + 1);
             DirectorShot.setInstanceCounter(maxInstance + 1);
             controllerManager.getScriptingProject().removeOffsettedCameraBlocks();
+            controllerManager.getScriptingProject().setChanged(false);
         }
     }
     

--- a/src/main/java/control/TimelineController.java
+++ b/src/main/java/control/TimelineController.java
@@ -343,10 +343,6 @@ public class TimelineController {
         if (directorShot != null) {
             directorShot.removeCameraShot(shot, timelineIndex);
 
-            // Delete the director shot if it's the last remaining camera shot
-            if (directorShot.getCameraShots().isEmpty()) {
-                controllerManager.getDirectorTimelineControl().removeShotNoCascade(directorShot);
-            } 
             shot.setDirectorShot(null);
         }
     }

--- a/src/main/java/control/ToolViewController.java
+++ b/src/main/java/control/ToolViewController.java
@@ -76,7 +76,6 @@ public class ToolViewController {
                                     || currentFocusClass.equals("javafx.scene.control.TextField")
                                     || currentFocusClass.equals("gui.headerarea.DoubleTextField")
                                     || currentFocusClass.equals("gui.headerarea.NumberTextField");
-                            System.out.println(isTextField);
                             if (!isTextField) {
                                 deleteActiveCameraShot();
                                 event.consume();

--- a/src/main/java/data/CameraShot.java
+++ b/src/main/java/data/CameraShot.java
@@ -15,7 +15,7 @@ import lombok.extern.log4j.Log4j2;
 @XmlRootElement(name = "cameraShot")
 @XmlAccessorType(XmlAccessType.FIELD)
 @Log4j2
-public class CameraShot extends Shot {
+public class CameraShot extends Shot implements Cloneable {
 
     // Counter that ensures no shots with duplicate numbers will be created. 
     @Setter @Getter
@@ -64,6 +64,21 @@ public class CameraShot extends Shot {
      */
     public CameraShot(String name, String description, double startCount, double endCount) {
         this(new GeneralShotData(name, description, startCount, endCount), null);
+    }
+    
+    @Override
+    public CameraShot clone() {
+        try {
+            super.clone();
+        } catch (CloneNotSupportedException e) {
+            e.printStackTrace();
+        }
+        CameraShot result = new CameraShot(getName(), getDescription(), getBeginCount(), getEndCount());
+        result.setDirectorShot(getDirectorShot());
+        result.setColliding(isColliding());
+        result.setInstruments(getInstruments());
+        result.setPresetId(getPresetId());
+        return result;
     }
 
     /**

--- a/src/main/java/data/CameraShot.java
+++ b/src/main/java/data/CameraShot.java
@@ -73,7 +73,8 @@ public class CameraShot extends Shot implements Cloneable {
         } catch (CloneNotSupportedException e) {
             e.printStackTrace();
         }
-        CameraShot result = new CameraShot(getName(), getDescription(), getBeginCount(), getEndCount());
+        CameraShot result = new CameraShot(getName(), getDescription(),
+                getBeginCount(), getEndCount());
         result.setDirectorShot(getDirectorShot());
         result.setColliding(isColliding());
         result.setInstruments(getInstruments());

--- a/src/main/java/gui/headerarea/DetailView.java
+++ b/src/main/java/gui/headerarea/DetailView.java
@@ -56,6 +56,7 @@ public class DetailView extends FlowPane {
      * Constructor.
      */
     public DetailView() {
+        this.setMinHeight(100);
         this.setHgap(TweakingHelper.GENERAL_SPACING);
         this.setVgap(TweakingHelper.GENERAL_SPACING);
         this.setStyle(style);
@@ -185,8 +186,8 @@ public class DetailView extends FlowPane {
         this.getChildren().removeAll(nameBox, descriptionBox, beginCountBox,
                 endCountBox, instrumentsBox);
         invisibleLabel = new Label("Select a shot to edit it.");
-        invisibleLabel.setPrefHeight(31);
-        invisibleLabel.setMinHeight(31);
+        invisibleLabel.setPrefHeight(50);
+        invisibleLabel.setMinHeight(50);
         invisibleLabel.setAlignment(Pos.CENTER);
     }
 

--- a/src/main/java/gui/modal/EditProjectModalView.java
+++ b/src/main/java/gui/modal/EditProjectModalView.java
@@ -21,6 +21,7 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
+import javafx.beans.value.ObservableValue;
 
 /**
  * Class responsible for displaying a modal view for editing a project.
@@ -178,7 +179,7 @@ public class EditProjectModalView extends ModalView {
         }
         initializeView();
     }
-
+    
     /**
      * Initialize the view of this modal.
      */

--- a/src/main/java/gui/modal/ModalView.java
+++ b/src/main/java/gui/modal/ModalView.java
@@ -49,17 +49,23 @@ public abstract class ModalView {
         this.modalStage.initOwner(rootPane.getPrimaryStage());
     }
     
+    /**
+     * Initialize the handler for the auto text field select.
+     */
     private void initTextFieldAutoSelect() {
-        System.out.println(modalStage);
-        System.out.println(modalStage.getScene());
-        System.out.println(modalStage.getScene().focusOwnerProperty());
-        
         modalStage.getScene().focusOwnerProperty().addListener(this::focusChangeListener);
     }
     
-    private void focusChangeListener(ObservableValue<? extends Node> observable, Node oldValue, Node newValue) {
+    /**
+     * Handler for auto text select.
+     Checks if the new selected Node is a text field, and selects text if needed
+     * @param observable the observable value
+     * @param oldValue the old node
+     * @param newValue the new node
+     */
+    private void focusChangeListener(ObservableValue<? extends Node> observable,
+            Node oldValue, Node newValue) {
         if (newValue != null) {
-            System.out.println("CLASS NAME NEW VALUE " + newValue.getClass().getName());
             String className = newValue.getClass().getName();
             if (className.equals("gui.styling.StyledTextfield")
                     || className.equals("gui.headerarea.NumberTextField")
@@ -67,8 +73,8 @@ public abstract class ModalView {
                     || className.equals("javafx.scene.control.TextField")) {
                 
                 Platform.runLater(() -> {
-                    ((TextField) newValue).selectAll();
-                });
+                        ((TextField) newValue).selectAll();
+                    });
             }
         }
     }

--- a/src/main/java/gui/modal/ModalView.java
+++ b/src/main/java/gui/modal/ModalView.java
@@ -3,7 +3,11 @@ package gui.modal;
 import gui.misc.TweakingHelper;
 import gui.root.RootPane;
 import gui.styling.StyledButton;
+import javafx.application.Platform;
+import javafx.beans.value.ObservableValue;
+import javafx.scene.Node;
 import javafx.scene.Scene;
+import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.layout.Pane;
@@ -44,6 +48,30 @@ public abstract class ModalView {
         this.modalStage.initModality(Modality.APPLICATION_MODAL);
         this.modalStage.initOwner(rootPane.getPrimaryStage());
     }
+    
+    private void initTextFieldAutoSelect() {
+        System.out.println(modalStage);
+        System.out.println(modalStage.getScene());
+        System.out.println(modalStage.getScene().focusOwnerProperty());
+        
+        modalStage.getScene().focusOwnerProperty().addListener(this::focusChangeListener);
+    }
+    
+    private void focusChangeListener(ObservableValue<? extends Node> observable, Node oldValue, Node newValue) {
+        if (newValue != null) {
+            System.out.println("CLASS NAME NEW VALUE " + newValue.getClass().getName());
+            String className = newValue.getClass().getName();
+            if (className.equals("gui.styling.StyledTextfield")
+                    || className.equals("gui.headerarea.NumberTextField")
+                    || className.equals("gui.headerarea.DoubleTextField")
+                    || className.equals("javafx.scene.control.TextField")) {
+                
+                Platform.runLater(() -> {
+                    ((TextField) newValue).selectAll();
+                });
+            }
+        }
+    }
 
     /**
      * If a child view has been added then the modal view is shown.
@@ -55,6 +83,8 @@ public abstract class ModalView {
             this.modalStage.getScene().getAccelerators()
                     .put(new KeyCodeCombination(KeyCode.ESCAPE),
                          this::hideModal);
+            initTextFieldAutoSelect();
+
         }
     }
 

--- a/src/test/java/control/TimelineControllerTest.java
+++ b/src/test/java/control/TimelineControllerTest.java
@@ -106,7 +106,6 @@ public class TimelineControllerTest extends ApplicationTest {
 
         timelineController.decoupleShot(0, shotSpy);
         verify(directorShotSpy).removeCameraShot(shotSpy, 0);
-        verify(directorTimelineController).removeShotNoCascade(directorShotSpy);
     }
 
     private void initRootPaneForCameraShotAdding() {


### PR DESCRIPTION
Fixes #178, #195, #196, #197, #198, #199, #200 
Director shot collision now updates appropriately
Camera shots are not linked anymore when created together
On application start, the changed boolean is now correctly set to false
Collisions are updated appropriately when creating camera shots via DirectorDetailView
Director shots are not deleted anymore when deleting a camera shot via detail view
You can now create director shots with 0 camera shots
Text in a text field is auto selected on focus.
